### PR TITLE
Clean-up

### DIFF
--- a/serialkm.py
+++ b/serialkm.py
@@ -378,7 +378,7 @@ def initialize(args):
 
     # Catch Error of wrong port: display all open ports instead
     if port.lower() in ('?', 'who', 'whois'):
-        if len(val_ports) == 0:
+        if not val_ports:
             print('\tNo valid ports found')
         else:
             print('\tValid ports:')
@@ -391,7 +391,7 @@ def initialize(args):
     except (ValueError, serial.SerialException):
         # https://pythonhosted.org/pyserial/pyserial_api.html?highlight=serial#serial.Serial
         print('Could not connect to Serial Port')
-        if len(val_ports) == 0:
+        if not val_ports == 0:
             print('\tNo valid ports found')
         else:
             print('\tValid ports:')

--- a/serialkm.py
+++ b/serialkm.py
@@ -1,15 +1,17 @@
 #!/home/keith/anaconda2/bin/python
-import serial
-import threading
+from __future__ import print_function
+
 import Queue
-import sys
-import time
-import argparse, textwrap
+import argparse
 import glob
-import struct
+import sys
+import textwrap
+import threading
+import time
 
+import serial
 
-'''
+"""
 adding folder to path
 INFO: http://stackoverflow.com/questions/15587877/run-a-python-script-in-terminal-without-the-python-command
 
@@ -19,88 +21,122 @@ Keeping folder in path
 INFO: http://superuser.com/questions/678113/how-to-add-a-line-to-bash-profile
 sudo echo 'export PATH=/home/keith/Documents/filesForProgramming/Libraries/runScripts/:$PATH' >>~/.bashrc
 
-'''
+"""
 
-class printQueueThread(threading.Thread):
+
+class PrintQueueThread(threading.Thread):
     def __init__(self, q, mode):
-	threading.Thread.__init__(self)
-	self._stop = threading.Event()
-	self.name = "SerialPrinter"
-	self.q = q
-	self.daemon = True
-	self.mode = mode
+        threading.Thread.__init__(self)
+        self._stop = threading.Event()
+        self.name = 'SerialPrinter'
+        self.q = q
+        self.daemon = True
+        self.mode = mode
+
     def run(self):
-	justPrintIt(self.q, self.mode)
+        just_print_it(self.q, self.mode)
+
     def stop(self):
-	self._stop.set()
+        self._stop.set()
+
     def stopped(self):
-	return self._stop.isSet()
+        return self._stop.isSet()
 
 
-class serialReadThread(threading.Thread):
+class SerialReadThread(threading.Thread):
     def __init__(self, ser, q):
-	threading.Thread.__init__(self)
-	self._stop = threading.Event()
-	self.name = "SerialReader"
-	self.q = q
-	self.ser = ser
-	self.daemon = True
+        threading.Thread.__init__(self)
+        self._stop = threading.Event()
+        self.name = 'SerialReader'
+        self.q = q
+        self.ser = ser
+        self.daemon = True
+
     def run(self):
-	mySerialRead(self.ser, self.q)
+        my_serial_read(self.ser, self.q)
+
     def stop(self):
-	self._stop.set()
+        self._stop.set()
+
     def stopped(self):
-	return self._stop.isSet()
+        return self._stop.isSet()
 
 
-class serialWriteThread(threading.Thread):
-    def __init__(self, ser, q, modeW):
-	threading.Thread.__init__(self)
-	self._stop = threading.Event()
-	self.name = "SerialWriter"
-	self.q = q
-	self.ser = ser
-	self.mode = modeW
-	self.daemon = True
+class SerialWriteThread(threading.Thread):
+    def __init__(self, ser, q, mode_w):
+        threading.Thread.__init__(self)
+        self._stop = threading.Event()
+        self.name = 'SerialWriter'
+        self.q = q
+        self.ser = ser
+        self.mode = mode_w
+        self.daemon = True
+
     def run(self):
-	mySerialWrite(self.ser, self.q, self.mode)
+        my_serial_write(self.ser, self.q, self.mode)
+
     def stop(self):
-	self._stop.set()
+        self._stop.set()
+
     def stopped(self):
-	return self._stop.isSet()
+        return self._stop.isSet()
+
 
 def interface():
-    defPort = serial_ports()
-    if (len(defPort) > 0):
-	defPort = defPort[-1]
-    else:
-	defPort = "/dev/ttyACM0"
+    try:
+        def_port = serial_ports().pop()
+    except IndexError:
+        def_port = '/dev/ttyACM0'
+
     args = argparse.ArgumentParser(
-	prog='SerialModuleKM.py',
-	formatter_class=argparse.RawDescriptionHelpFormatter,
-	description='This is a simple python based serial monitor')
-    args.add_argument('-p', '--port', default=defPort, help='Serial Port')
-    args.add_argument('-b', '--baudrate', type=int, default=9600, help='Baudrate')
-    args.add_argument('-t', '--time-out', type=float, default=0.01, help='Time Out')
-    args.add_argument('-m', '--mode', default="s", help="Mode for Incoming Data: 's':String, 'b':Binary, 'h':Hex")
-    args.add_argument('-w', '--write-mode', default="s", help="Mode for User Input Data: 's':String, 'b':Binary, 'h':Hex")
+        prog='SerialModuleKM.py',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='This is a simple python based serial monitor')
+    args.add_argument(
+        '-p',
+        '--port',
+        default=def_port,
+        help='Serial Port')
+    args.add_argument(
+        '-b',
+        '--baudrate',
+        type=int,
+        default=9600,
+        help='Baudrate')
+    args.add_argument(
+        '-t',
+        '--time-out',
+        type=float,
+        default=0.01,
+        help='Time Out')
+    args.add_argument(
+        '-m',
+        '--mode',
+        default='s',
+        help="Mode for Incoming Data: 's':String, 'b':Binary, 'h':Hex")
+    args.add_argument(
+        '-w',
+        '--write-mode',
+        default='s',
+        help="Mode for User Input Data: 's':String, 'b':Binary, 'h':Hex")
     args = args.parse_args()
     return args
 
+
 def serial_ports():
     """
-	http://stackoverflow.com/questions/12090503
-	    Author: http://stackoverflow.com/users/300783/thomas
-	Lists serial ports
+    http://stackoverflow.com/questions/12090503
+        Author: http://stackoverflow.com/users/300783/thomas
+    Lists serial ports
     :raises EnvironmentError:
         On unsupported or unknown platforms
     :returns:
         A list of available serial ports
     """
     if sys.platform.startswith('win'):
-        ports = ['COM' + str(i + 1) for i in range(256)]
+        ports = ['COM' + str(i) for i in xrange(1, 257)]
     elif sys.platform.startswith('linux') or sys.platform.startswith('cygwin'):
-        # this is to exclude your current terminal "/dev/tty"
+        # this is to exclude your current terminal '/dev/tty'
         ports = glob.glob('/dev/tty[A-Za-z]*')
     elif sys.platform.startswith('darwin'):
         ports = glob.glob('/dev/tty.*')
@@ -116,374 +152,298 @@ def serial_ports():
             pass
     return result
 
-def justPrintIt(q, mode):
-    i = 3
-    recentMessage = False
-    while True:
-	if not q.empty():
-	    msg = q.get()
-	    if (msg[0] == 'E'):
-		sys.stdout.write(str(msg[1]))
-	    else:
-		msg = msg[1]
-		if (mode == 's'):
-		    sys.stdout.write(str(msg))
-		elif (mode == 'b'):
-		    binMsg = "".join("{:08b}".format(ord(c), 'b') for c in str(msg))
-		    sys.stdout.write(str(binMsg))
-		    sys.stdout.write(":")
-		elif (mode == 'h'):
-		    hexMsg = ":".join("{:02x}".format(ord(c)) for c in str(msg))
-		    sys.stdout.write(str(hexMsg))
-		    sys.stdout.write(":")
-	    q.task_done()
-	    recentMessage = True
-	    i = 0
-	else:
-	    time.sleep(0.01)
-	    i += 1
-	    if( (recentMessage == True) and (i > 3)):
-		recentMessage = False
-		i = 0
-		sys.stdout.write("\n")
 
-def mySerialRead(ser, q):
-    msgArray = []
-    msgStr = ""
+def just_print_it(q, mode):
     i = 3
-    recentMessage = False
+    recent_message = False
     while True:
-	try:
-	    msg = ser.read()
-	except:
-	    msg = ""
-	if (msg != ""):
-	    q.put(("R", msg))
-	    recentMessage = True
-	    i = 0
-	else:
-	    i += 1
-	    time.sleep(0.001)
-	    if( (recentMessage == True) and (i > 3)):
-		recentMessage = False
-		i = 0
-		#q.put("\n")
+        if not q.empty():
+            msg = q.get()
+            if msg[0] == 'E':
+                sys.stdout.write(str(msg[1]))
+            else:
+                msg = msg[1]
+                if mode == 's':
+                    sys.stdout.write(str(msg))
+                elif mode == 'b':
+                    bin_msg = ''.join(
+                        '{:08b}'.format(ord(c), 'b') for c in str(msg))
+                    sys.stdout.write(str(bin_msg))
+                    sys.stdout.write(':')
+                elif mode == 'h':
+                    hex_msg = ':'.join(
+                        '{:02x}'.format(ord(c)) for c in str(msg))
+                    sys.stdout.write(str(hex_msg))
+                    sys.stdout.write(':')
+            q.task_done()
+            recent_message = True
+            i = 0
+        else:
+            time.sleep(0.01)
+            i += 1
+            if recent_message is True and i > 3:
+                recent_message = False
+                i = 0
+                sys.stdout.write('\n')
 
-def hexParse(rawMsg):
+
+def my_serial_read(ser, q):
+    i = 3
+    recent_message = False
+    while True:
+        try:
+            msg = ser.read()
+        except:
+            msg = ''
+        if msg != '':
+            q.put(('R', msg))
+            recent_message = True
+            i = 0
+        else:
+            i += 1
+            time.sleep(0.001)
+            if recent_message is True and i > 3:
+                recent_message = False
+                i = 0
+                # q.put('\n')
+
+
+def hex_parse(raw_msg):
     # Parsing
-    tempMsg = rawMsg.upper()
-    tempMsg = tempMsg.split('0X')
-    tempMsg = "".join(tempMsg)
-    tempMsg = tempMsg.split('\X')
-    tempMsg = "".join(tempMsg)
-    hexMsg = 0x00
-    if(len(tempMsg) > 2):
-	if ((tempMsg[0] == "0") and (tempMsg[1] == "X")):
-	    tempMsg = tempMsg[2:]
-    hexVals = set('0123456789ABCDEF')
-    tempMsg = "".join(c for c in tempMsg if c in hexVals)
+    temp_msg = ''.join(raw_msg.upper().split('0X'))
+    temp_msg = ''.join(temp_msg.split('\X'))
+    if len(temp_msg) > 2 and temp_msg.startswith('0X'):
+        temp_msg = temp_msg[2:]
+    hex_vals = set('0123456789ABCDEF')
+    temp_msg = "".join(c for c in temp_msg if c in hex_vals)
 
-    # Varibles used
-    hexMsg = ""
-    byteHold = 0x00
-    byteArr = []
+    # Variables used
+    byte_hold = 0x00
+    byte_arr = []
 
-    
+    hex_str_to_int = {'0': 0x00, '1': 0x01, '2': 0x02, '3': 0x03, '4': 0x04,
+                      '5': 0x05, '6': 0x06, '7': 0x07, '8': 0x08, '9': 0x09,
+                      'A': 0x0A, 'B': 0x0B, 'C': 0x0C, 'D': 0x0D, 'E': 0x0E,
+                      'F': 0x0F}
     # Start with most sig byte
-    sigBytePoint = len(tempMsg)% 2
-    if (sigBytePoint == 1):
-	# Pack the first Byte
-	if (tempMsg[0] == '0'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x00
-	elif (tempMsg[0] == '1'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x01
-	elif (tempMsg[0] == '2'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x02
-	elif (tempMsg[0] == '3'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x03
-	elif (tempMsg[0] == '4'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x04
-	elif (tempMsg[0] == '5'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x05
-	elif (tempMsg[0] == '6'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x06
-	elif (tempMsg[0] == '7'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x07
-	elif (tempMsg[0] == '8'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x08
-	elif (tempMsg[0] == '9'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x09
-	elif (tempMsg[0] == 'A'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0A
-	elif (tempMsg[0] == 'B'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0B
-	elif (tempMsg[0] == 'C'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0C
-	elif (tempMsg[0] == 'D'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0D
-	elif (tempMsg[0] == 'E'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0E
-	elif (tempMsg[0] == 'F'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0F	
-    	byteArr.append(byteHold)
-    # Rest of sting/bytes
-    byteHold = 0x00
+    sig_byte_point = len(temp_msg) % 2
+    if sig_byte_point == 1:
+        # Pack the first Byte
+        try:
+            val = hex_str_to_int[temp_msg[0]]
+        except KeyError:
+            pass
+        else:
+            byte_hold <<= 4
+            byte_hold |= val
+
+        byte_arr.append(byte_hold)
+    # Rest of string/bytes
+    byte_hold = 0x00
 
     action = 0
-    for i in range(sigBytePoint, len(tempMsg)):
-	if (tempMsg[i] == '0'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x00
-	elif (tempMsg[i] == '1'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x01
-	elif (tempMsg[i] == '2'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x02
-	elif (tempMsg[i] == '3'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x03
-	elif (tempMsg[i] == '4'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x04
-	elif (tempMsg[i] == '5'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x05
-	elif (tempMsg[i] == '6'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x06
-	elif (tempMsg[i] == '7'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x07
-	elif (tempMsg[i] == '8'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x08
-	elif (tempMsg[i] == '9'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x09
-	elif (tempMsg[i] == 'A'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0A
-	elif (tempMsg[i] == 'B'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0B
-	elif (tempMsg[i] == 'C'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0C
-	elif (tempMsg[i] == 'D'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0D
-	elif (tempMsg[i] == 'E'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0E
-	elif (tempMsg[i] == 'F'):
-	    byteHold = byteHold << 4
-	    byteHold = byteHold | 0x0F
-	action += 1
-	if (action == 2):
-	    byteArr.append(byteHold)
-	    byteHold = 0x00
-	    action = 0
+    for i in xrange(sig_byte_point, len(temp_msg)):
+        try:
+            val = hex_str_to_int[temp_msg[i]]
+        except KeyError:
+            pass
+        else:
+            byte_hold <<= 4
+            byte_hold |= val
 
-	
-    hexMsg = "".join(chr(x) for x in byteArr)
-    return hexMsg
+        action += 1
+        if action == 2:
+            byte_arr.append(byte_hold)
+            byte_hold = 0x00
+            action = 0
 
-def binParse(rawMsg):
+    hex_msg = ''.join(chr(x) for x in byte_arr)
+    return hex_msg
+
+
+def bin_parse(raw_msg):
     # Parsing Input string
-    tempMsg = rawMsg.upper()
-    tempMsg = tempMsg.split('0B')
-    tempMsg = "".join(tempMsg)
-    if(len(tempMsg) > 2):
-	if ((tempMsg[0] == "0") and (tempMsg[1] == "B")):
-	    tempMsg = tempMsg[2:]
-    binVals = set('01')
-    tempMsg = "".join(c for c in tempMsg if c in binVals)
+    temp_msg = ''.join(raw_msg.upper().split('0B'))
+    if len(temp_msg) > 2 and temp_msg.startswith('0B'):
+        temp_msg = temp_msg[2:]
+    temp_msg = ''.join(c for c in temp_msg if c in '01')
 
-    # Varibles used
-    binMsg = ""
-    byteHold = 0x00
-    byteArr = []
+    # Variables used
+    # bin_msg = ''
+    byte_hold = 0x00
+    byte_arr = []
+
+    bin_str_to_int = {'0': 0x00, '1': 0x01}
 
     # Start with most sig byte
-    sigBytePoint = len(tempMsg)% 8 
-    if (sigBytePoint != 0):
-	# first len(tempMsg)% 8 will be stuffed into own byte 
-	# Packing the first byte
-	for i in range(sigBytePoint):
-	    if (tempMsg[i] == '0'):
-		byteHold = byteHold << 1
-		byteHold = byteHold | 0x00
-	    elif (tempMsg[i] == '1'):
-		byteHold = byteHold << 1
-		byteHold = byteHold | 0x01
-	byteArr.append(byteHold)
+    sig_byte_point = len(temp_msg) % 8
+    if sig_byte_point != 0:
+        # first len(temp_msg) % 8 will be stuffed into own byte
+        # Packing the first byte
+        for i in xrange(sig_byte_point):
+            try:
+                val = bin_str_to_int[temp_msg[i]]
+            except KeyError:
+                pass
+            else:
+                byte_hold <<= 1
+                byte_hold |= val
+
+        byte_arr.append(byte_hold)
     # Rest of sting/bytes
-    byteHold = 0x00
-    for i in range(sigBytePoint, len(tempMsg)):
-	if (tempMsg[i] == '0'):
-	    byteHold = byteHold << 1
-	    byteHold = byteHold | 0x00
-	elif (tempMsg[i] == '1'):
-	    byteHold = byteHold << 1
-	    byteHold = byteHold | 0x01
-	if ((i-sigBytePoint+1)%8 == 0):
-	    byteArr.append(byteHold)
-	    byteHold = 0x00
+    byte_hold = 0x00
+    for i in xrange(sig_byte_point, len(temp_msg)):
+        try:
+            val = bin_str_to_int[temp_msg[i]]
+        except KeyError:
+            pass
+        else:
+            byte_hold <<= 1
+            byte_hold |= val
 
-    binMsg = "".join(chr(x) for x in byteArr)
-    #print hex(binMsg)
-    return binMsg
+        if (i - sig_byte_point + 1) % 8 == 0:
+            byte_arr.append(byte_hold)
+            byte_hold = 0x00
 
-def parseAll(rawMsg):
-    if(len(rawMsg) > 2):
-	if (rawMsg[0] == '0'):
-	    if ((rawMsg[1] == 'b') or (rawMsg[1] == 'B')):
-		cleanMsg = binParse(rawMsg)
-	    elif ((rawMsg[1] == 'x') or (rawMsg[1] == 'X')):
-		cleanMsg = hexParse(rawMsg)
-	    else:
-		cleanMsg = rawMsg
-	else:
-	    cleanMsg = rawMsg
+    bin_msg = ''.join(chr(x) for x in byte_arr)
+    # print hex(binMsg)
+    return bin_msg
+
+
+def parse_all(raw_msg):
+    if len(raw_msg) > 2:
+        if raw_msg[0] == '0':
+            if raw_msg[1] in 'bB':
+                clean_msg = bin_parse(raw_msg)
+            elif raw_msg[1] in 'xX':
+                clean_msg = hex_parse(raw_msg)
+            else:
+                clean_msg = raw_msg
+        else:
+            clean_msg = raw_msg
     else:
-	cleanMsg = rawMsg
-    return cleanMsg
+        clean_msg = raw_msg
+    return clean_msg
 
-def mySerialWrite(ser, q, mode):
 
+def my_serial_write(ser, q, mode):
     while True:
-	myMsg = raw_input() # If in python 3, change raw_input() to input()
-	if (myMsg != ""):
-	    if (mode == 'a'):
-		myMsg = parseAll(myMsg)		
-		ser.write(myMsg)
-	    elif (mode == 'h'):
-		myMsg = hexParse(myMsg)		
-		ser.write(myMsg)
-	    elif (mode == 'b'):
-		myMsg = binParse(myMsg)		
-		ser.write(myMsg)
-	    else:
-		ser.write(myMsg)
-	    #try:
-		#print "KM"#ser.write(myMsg)
-	    #except:
-		#q.put(("E", str("Could not Send: " + str(myMsg))))
-	else:
-	    time.sleep(0.001)
-    
+        my_msg = raw_input()  # If in python 3, change raw_input() to input()
+        if my_msg != '':
+            if mode == 'a':
+                my_msg = parse_all(my_msg)
+            elif mode == 'h':
+                my_msg = hex_parse(my_msg)
+            elif mode == 'b':
+                my_msg = bin_parse(my_msg)
+            # else:
+            #     try:
+            #         print 'KM'#ser.write(myMsg)
+            #     except:
+            #     q.put(('E', str('Could not Send: ' + str(myMsg))))
+            ser.write(my_msg)
 
-def initalize(args):
+        else:
+            time.sleep(0.001)
+
+
+def initialize(args):
     q = Queue.Queue()
     port = args.port
-    valPorts = serial_ports()
-    myBaud = args.baudrate
-    myTimeOut = args.time_out
+    val_ports = serial_ports()
+    my_baud = args.baudrate
+    my_time_out = args.time_out
 
     # Verify that the input mode is valid, if not, treat RX as a char
-    mode = args.mode
-    mode = mode.lower()
-    modeDict = {'s': 's', 'str':'s', 'string':'s',\
-		'b': 'b', 'bin':'b', 'binary':'b',\
-		'h': 'h', 'hex':'h', 'hexadecimal':'h'}
-    if (mode not in modeDict):
-	mode = 's'
-	print "   *** RX is being treated as characters, Your input was invalid                *"
-	print "   *** Please use either  's' for String, 'b' forBinary, or 'h' for Hexadecimal *"
-    else:
-	mode = modeDict[mode]
+    mode = args.mode.lower()
+    mode_dict = {'s': 's', 'str': 's', 'string': 's',
+                 'b': 'b', 'bin': 'b', 'binary': 'b',
+                 'h': 'h', 'hex': 'h', 'hexadecimal': 'h'}
+    try:
+        mode = mode_dict[mode]
+    except KeyError:
+        mode = 's'
+        print('   *** RX is being treated as characters, Your input was invalid                *')
+        print("   *** Please use either  's' for String, 'b' for Binary, or 'h' for Hexadecimal *")
 
-    wmode = args.write_mode
-    wmode = wmode.lower()
-    modeDict = {'s': 's', 'str':'s', 'string':'s',\
-		'b': 'b', 'bin':'b', 'binary':'b',\
-		'h': 'h', 'hex':'h', 'hexadecimal':'h',\
-		'a': 'a', 'all':'a', 'any':'a', 'anything':'a'}
-    if (wmode not in modeDict):
-	wmode = 's'
-	print "   *** TX is being treated as characters, Your input was invalid                *"
-	print "   *** Please use either  's' for String, 'b' forBinary, or 'h' for Hexadecimal *"
-    else:
-	wmode = modeDict[wmode]
+    wmode = args.write_mode.lower()
+    mode_dict.update({'a': 'a', 'all': 'a', 'any': 'a', 'anything': 'a'})
+
+    try:
+        wmode = mode_dict[wmode]
+    except KeyError:
+        wmode = 's'
+        print('   *** TX is being treated as characters, Your input was invalid                *')
+        print("   *** Please use either  's' for String, 'b' for Binary, or 'h' for Hexadecimal *")
 
     # Catch Error of wrong port: display all open ports instead
-    if (port == '?') or (port.lower() == 'who') or (port.lower() == 'whois'):
-	if (len(valPorts) == 0):
-	    print "\tNo valid ports found"
-	else:
-	    print "\tValid ports:"
-	    for i in range(len(valPorts)):
-		print "\t\t", valPorts[i]
-	return
-	
+    if port.lower() in ('?', 'who', 'whois'):
+        if len(val_ports) == 0:
+            print('\tNo valid ports found')
+        else:
+            print('\tValid ports:')
+            for port in val_ports:
+                print('\t\t{}'.format(port))
+        return
+
     try:
-	ser = serial.Serial(port, baudrate = myBaud, timeout = myTimeOut)
-    except:
-	print "Could not connect to Serial Port"
-	if (len(valPorts) == 0):
-	    print "\tNo valid ports found"
-	else:
-	    print "\tValid ports:"
-	    for i in range(len(valPorts)):
-		print "\t\t", valPorts[i]
-	return
+        ser = serial.Serial(port, baudrate=my_baud, timeout=my_time_out)
+    except (ValueError, serial.SerialException):
+        # https://pythonhosted.org/pyserial/pyserial_api.html?highlight=serial#serial.Serial
+        print('Could not connect to Serial Port')
+        if len(val_ports) == 0:
+            print('\tNo valid ports found')
+        else:
+            print('\tValid ports:')
+            for port in val_ports:
+                print('\t\t{}'.format(port))
+        return
 
     # Start up
-    connected = False 
-    print "\t*****************************************"
-    print "\t* Opening Serial Port Communication\t*"
-    print "\t*\tPort:      \t", port, "\t*"
-    print "\t*\tBaudrate:  \t", myBaud, "\t\t*"
-    print "\t*\tTime Out:  \t", myTimeOut, "\t\t*"
-    print "\t*\tPrint Mode:\t'", mode, "'\t\t*"
-    print "\t*\tWrite Mode:\t'", wmode, "'\t\t*"
+    connected = False
+    print(textwrap.dedent("""\
+        \t*****************************************
+        \t* Opening Serial Port Communication\t*
+        \t*\tPort:      \t{}\t*
+        \t*\tBaudrate:  \t{}\t\t*
+        \t*\tTime Out:  \t{}\t\t*
+        \t*\tPrint Mode:\t'{}'\t\t*
+        \t*\tWrite Mode:\t'{}'\t\t*
+        """.format(port, my_baud, my_time_out, mode, wmode)))
+
     while not connected:
-	ser.read()
-	connected = True
-    print "\t*\tSerial Communication Open\t*"
-    print "\t*****************************************"
+        ser.read()
+        connected = True
+    print(textwrap.dedent("""\
+        \t*\tSerial Communication Open\t*
+        \t*****************************************
+        """))
 
-    printThread = printQueueThread(q, mode)
-    readThread = serialReadThread(ser, q)
-    writeThread = serialWriteThread(ser, q, wmode)
-    
-    try: 
-	printThread.start()
-	readThread.start()
-	writeThread.start()
-	while True:
-	    time.sleep(1)
+    print_thread = PrintQueueThread(q, mode)
+    read_thread = SerialReadThread(ser, q)
+    write_thread = SerialWriteThread(ser, q, wmode)
+
+    try:
+        print_thread.start()
+        read_thread.start()
+        write_thread.start()
+        while True:
+            time.sleep(1)
     except(KeyboardInterrupt, SystemExit):
-	# Allows for clean exiting
-	writeThread.stop()
-	readThread.stop()
-	printThread.stop()
-	ser.close()
-	time.sleep(0.001)
-	print "\t*****************************************"
-	print "\t* Exited Serial Port Communication\t*"
-	print "\t*****************************************"
-
+        # Allows for clean exiting
+        write_thread.stop()
+        read_thread.stop()
+        print_thread.stop()
+        ser.close()
+        time.sleep(0.001)
+        print(textwrap.dedent("""\
+            \t*****************************************
+            \t* Exited Serial Port Communication\t*
+            \t*****************************************
+            """))
 
     return
 
-initalize(interface())
 
-        
+if __name__ == '__main__':
+    initialize(interface())


### PR DESCRIPTION
### General

* Re-order imports (add `__future__.print_function`)
* Remove unused import `struct`
* Remove redundant parentheses
* Rename classes using CamelCase
* Rename functions using snake_case
* Rename variables using snake_case
* Use spaces instead of tabs for indentation
* Use `xrange` instead of `range`
* Add blank lines between method declarations
* Replace most double-quotes with single-quotes for consistency
* Use `is True` instead of `== True`
* Remove unused variables

`serialtool.interface`

* Use EAFP instead of LBYL
* Add space in between argparse arguments for readability

`serialtool.serial_ports`

* Modify `range` args to eliminate need for `+ 1` each time

`serialtool.hex_parse`

* Simplify `temp_msg` creation
* Replace (16 * 2) if/elif checks with a try/except using a dictionary

`serialtool.bin_parse`

* Simplify 'temp_msg' creation
* Replace if/elif checks with a try/except using a dictionary

`serialtool.parse_all`

* Simplify `raw_msg` checks

`serialtool.my_serial_write`

* Moved `ser.write(my_msg)` underneath if/elif/else for less duplication

`serialtool.initialize`

* Use EAFP instead of LBYL
* Update `mode_dict` instead of creating a whole new dict
* Simplify `port` checks
* Add specific errors instead of `except:` (comment with source link for specific errors)
* Use `textwrap.dedent` to print single multi-line strings instead of one `print` statement per line
* `if not val_ports:` instead of `if len(val_ports) == 0:`
